### PR TITLE
docs: improve Iranian HSM visa roadmap for clarity and flow

### DIFF
--- a/Netherlands/ROADMAP.md
+++ b/Netherlands/ROADMAP.md
@@ -1,31 +1,47 @@
-### Roadmap for Iranian Visa HSM (Highly Skilled Migrant)
 
-If you're a highly skilled developer from Iran seeking to obtain the **HSM visa** sponsorship for relocation to the Netherlands, here’s a step-by-step roadmap that will guide you through the necessary processes:
 
-1. **Find a Job for Relocation**  
-   Your first step is to secure a job that offers sponsorship for the HSM visa. Employers in the Netherlands who are registered with the IND (Immigration and Naturalization Service) can sponsor you.  
-   - **Check the Job Documentation**: Review the job process and available positions in the Netherlands. Understanding the job market and opportunities is essential.
+### 🇳🇱 Roadmap for Iranian Highly Skilled Migrants (HSM Visa)
 
-2. **Familiarize Yourself with the IND Processes**  
-   The IND plays a central role in processing your HSM visa. It's important to understand their requirements and procedures for a smooth application process.  
-   - **IND Processes Documentation**: Take a detailed look at how the IND handles visa applications, residence permits, and other important procedures.
+If you're a skilled developer from Iran aiming to relocate to the Netherlands through the **Highly Skilled Migrant (HSM) visa**, this roadmap will guide you through each essential step of the journey — from finding a job to settling in your new home.
 
-3. **Understand the Visa Process**  
-   Make sure you fully understand the steps involved in applying for an HSM visa. This will help you prepare the necessary documents and follow the correct procedure.  
-   - **Visa Process Documentation**: Review the required steps for obtaining your HSM visa, including the necessary forms, supporting documents, and processing times.
 
-4. **Prepare Embassy Documents**  
-   Once you are familiar with the visa process, gather the required documents for your embassy appointment. Different embassies may have specific requirements.  
-   - **Embassy Required Documents**: Be sure to check the Dutch embassy's requirements in your region (Iran) to ensure you have everything ready for submission.
+#### 1. 🧑‍💻 Secure a Job with HSM Sponsorship  
+Your first step is to find a Dutch employer who is recognized by the **IND (Immigration and Naturalization Service)** and is authorized to sponsor HSM visa candidates.  
+- **Research the Job Market**: Explore tech job opportunities and companies that offer HSM sponsorship.  
+- **Job Offer Requirement**: Ensure the role you're applying for meets the salary and qualification criteria set by the IND.
 
-5. **Post-Visa: Residence Permit Card**  
-   After receiving your visa, you need to apply for a residence permit card from the IND. This will allow you to officially live and work in the Netherlands.  
-   - **Residence Permit Documentation**: Learn how to apply for your residence permit card after your arrival in the Netherlands.
 
-6. **Municipality Registration**  
-   Upon arrival in the Netherlands, you must register your address with the local municipality. This is required to complete your residency process.  
-   - **Municipality Registration Documentation**: Ensure you have the right documents to register with the municipality and obtain your BSN (Citizen Service Number).
+#### 2. 📋 Understand IND Requirements  
+The IND is the authority that processes residence permits, including the HSM visa. Understanding their expectations will help you avoid delays.  
+- **Familiarize Yourself with IND Procedures**: Learn about required documents, timelines, and the employer's role in the visa process.  
+- **Stay Up to Date**: Rules can change — always consult the [official IND website](https://ind.nl) for the latest information.
 
-7. **Set Up a Bank Account and SIM Card**  
-   Once you’ve completed the registration process, you will need a Dutch bank account for financial transactions and a SIM card for communication.  
-   - **Bank Account and SIM Card Setup**: Learn how to open a bank account and obtain a SIM card in the Netherlands, both essential for daily life.
+
+#### 3. 🛂 Navigate the Visa Application Process  
+Once you have a job offer, the visa application process begins. Your employer usually initiates this on your behalf.  
+- **Review Visa Steps**: Understand the sequence — employer submits the application, you receive the MVV (provisional visa), then travel to the Netherlands.  
+- **Gather Supporting Documents**: Prepare personal documents (passport, birth certificate, diplomas, etc.) as required by the IND.
+
+
+#### 4. 🏛️ Prepare for Your Embassy Appointment  
+If you're in Iran, you’ll likely visit the Dutch embassy in Tehran for your MVV appointment.  
+- **Check Local Embassy Guidelines**: Embassy requirements can differ — review specific instructions and book an appointment in advance.  
+- **Bring the Right Documents**: This often includes your passport, biometric data, and any additional forms the embassy requests.
+
+
+#### 5. 🏠 Arrival and Residence Permit Collection  
+After arriving in the Netherlands, your next step is collecting your residence permit card from the IND.  
+- **IND Appointment**: You’ll receive instructions on when and where to pick up your permit.  
+- **Permit Validity**: This card legally allows you to live and work in the Netherlands as a highly skilled migrant.
+
+
+#### 6. 🏢 Register with the Municipality  
+You must register at your local **municipality (gemeente)** within five days of arrival.  
+- **BSN Number**: This process will issue your **BSN (Citizen Service Number)**, required for everything from opening a bank account to getting health insurance.  
+- **Required Documents**: Bring your rental contract and passport/residence permit.
+
+
+#### 7. 💳 Set Up Essentials: Bank Account & SIM Card  
+Once registered, you can start setting up your daily life.  
+- **Bank Account**: Required for salary deposits, rent payments, and insurance. Some banks may require a BSN or proof of address.  
+- **SIM Card**: Get a Dutch number for communication, banking, and identity verification.


### PR DESCRIPTION
This PR updates and refines the existing "Roadmap for Iranian Visa HSM" document. The goal is to make the content more clear, structured, and actionable for Iranian developers seeking relocation to the Netherlands via the Highly Skilled Migrant (HSM) visa route.

This closes #4 